### PR TITLE
Support For Laravel 9 and update to UIkit 3.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         }
     ],
     "require": {
-        "illuminate/contracts": "^8.0",
-        "laravel/breeze": "^1.0"
+        "illuminate/contracts": "^8.0||^9.0",
+        "laravel/breeze": "^1.8"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.3",
-        "vimeo/psalm": "^3.11"
+        "friendsofphp/php-cs-fixer": "^3.6",
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.5",
+        "vimeo/psalm": "^4.20"
     },
     "autoload": {
         "psr-4": {

--- a/stubs/package.json
+++ b/stubs/package.json
@@ -10,17 +10,17 @@
     "prod": "npm run production"
   },
   "devDependencies": {
-    "browser-sync": "^2.26.13",
-    "browser-sync-webpack-plugin": "^2.2.2",
-    "laravel-mix": "^6.0.6",
-    "postcss": "^8.2.4",
-    "resolve-url-loader": "^3.1.0",
-    "sass": "^1.32.2",
-    "sass-loader": "^8.0.2"
+    "browser-sync": "^2.27.7",
+    "browser-sync-webpack-plugin": "^2.3.0",
+    "laravel-mix": "^6.0.42",
+    "postcss": "^8.4.6",
+    "resolve-url-loader": "^5.0.0",
+    "sass": "^1.49.7",
+    "sass-loader": "^12.6.0"
   },
   "dependencies": {
-    "jquery": "^3.5.0",
+    "jquery": "^3.6.0",
     "js-dom-router": "^1.0.0",
-    "uikit": "^3.5.0"
+    "uikit": "^3.11.1"
   }
 }


### PR DESCRIPTION
This PR updates the dependencies to their latest version and allows support for Laravel 9.